### PR TITLE
Support for Message Reactions and Custom Guilds on Messages also Changed Export Mechanics.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.gitignore
+.nycrc
+test/
+coverage/
+.nyc_output/
+.github/
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "mock-discord.js",
-  "version": "1.0.0",
+  "name": "@lambocreeper/mock-discord.js",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -379,6 +379,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
       "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -387,6 +388,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -395,6 +397,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
       "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
         "@sinonjs/samsam": "^5.0.2"
@@ -404,6 +407,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
       "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -413,7 +417,8 @@
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.2.13",
@@ -997,7 +1002,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -1955,7 +1961,8 @@
     "just-extend": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -1991,7 +1998,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -2165,6 +2173,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
       "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
@@ -2507,6 +2516,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -2514,7 +2524,8 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         }
       }
     },
@@ -2764,9 +2775,10 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
-      "integrity": "sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
@@ -2780,12 +2792,14 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -3082,7 +3096,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mock-discord.js",
-  "version": "1.0.0",
+  "name": "@lambocreeper/mock-discord.js",
+  "version": "1.0.2",
   "description": "Easily mock Discord.js for testing your bot's code.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -42,11 +42,11 @@
     "eslint-config-codesupport": "^1.0.2",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
+    "sinon": "^9.2.1",
     "ts-mocha": "^7.0.0",
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "discord.js": "^12.3.1",
-    "sinon": "^9.2.0"
+    "discord.js": "^12.3.1"
   }
 }

--- a/src/BaseMocks.ts
+++ b/src/BaseMocks.ts
@@ -6,6 +6,7 @@ import TEXT_CHANNEL_DEFAULTS from "./defaults/textchannel";
 import USER_DEFAULTS from "./defaults/user";
 import getGuildMemberDefaults from "./defaults/guildmember";
 import getMessageDefaults from "./defaults/message";
+import getMessageReactionDefaults from "./defaults/messagerReaction";
 
 class BaseMocks {
 	private static client: Discord.Client;
@@ -16,6 +17,7 @@ class BaseMocks {
 	private static user: Discord.User;
 	private static guildMember: Discord.GuildMember;
 	private static message: Discord.Message;
+	private static messageReaction: Discord.MessageReaction;
 
 	/**
 	 * Returns a generic and consistent mock of a Discord Client.
@@ -119,6 +121,21 @@ class BaseMocks {
 		}
 
 		return this.message;
+	}
+
+	/**
+	 * Returns a generic and consistent mock of a Discord Message Reaction.
+	 *
+	 * @returns {Discord.MessageReaction}
+	 */
+	static getMessageReaction(): Discord.MessageReaction {
+		if (!this.messageReaction) {
+			this.messageReaction = new Discord.MessageReaction(
+				this.getClient(), getMessageReactionDefaults(), this.getMessage()
+			);
+		}
+
+		return this.messageReaction;
 	}
 }
 

--- a/src/CustomMocks.ts
+++ b/src/CustomMocks.ts
@@ -16,6 +16,9 @@ import TEXT_CHANNEL_DEFAULTS from "./defaults/textchannel";
 import USER_DEFAULTS from "./defaults/user";
 import getGuildMemberDefaults from "./defaults/guildmember";
 import getMessageDefaults from "./defaults/message";
+import MessageReactionOptions from "./interfaces/MessageReactionOptions";
+import CustomMessageReactionExtras from "./interfaces/CustomMessageReactionExtras";
+import getMessageReactionDefaults from "./defaults/messagerReaction";
 
 class CustomMocks {
 	/**
@@ -100,6 +103,18 @@ class CustomMocks {
 			...getMessageDefaults(),
 			...options
 		}, extras?.channel ?? BaseMocks.getTextChannel());
+	}
+
+	/**
+	 * Returns a message reaction based off of given options.
+	 *
+	 * @returns {Discord.MessageReaction}
+	 */
+	static getMessageReaction(options?: MessageReactionOptions, extras?: CustomMessageReactionExtras): Discord.MessageReaction {
+		return new Discord.MessageReaction(extras?.client ?? BaseMocks.getClient(), {
+			...getMessageReactionDefaults(),
+			...options
+		}, extras?.message ?? BaseMocks.getMessage());
 	}
 }
 

--- a/src/defaults/message.ts
+++ b/src/defaults/message.ts
@@ -8,6 +8,7 @@ function getMessageDefaults(): MessageConfigOptions {
 		content: "This is a message.",
 		author: BaseMocks.getUser(),
 		member: BaseMocks.getGuildMember(),
+		guild: BaseMocks.getGuild(),
 		pinned: false,
 		tts: false
 	};

--- a/src/defaults/messagerReaction.ts
+++ b/src/defaults/messagerReaction.ts
@@ -1,0 +1,14 @@
+import MessageReactionOptions from "../interfaces/MessageReactionOptions";
+import BaseMocks from "../BaseMocks";
+
+// This has to be declared like this otherwise an error occurs stating BaseMocks is not defined.
+function getMessageReactionDefaults(): MessageReactionOptions {
+	return {
+		message: BaseMocks.getMessage(),
+		emoji: {
+			name: "my-emoji"
+		}
+	};
+}
+
+export default getMessageReactionDefaults;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,2 @@
-import BaseMocks from "./BaseMocks";
-import CustomMocks from "./CustomMocks";
-
-export default {
-	BaseMocks,
-	CustomMocks
-};
+export * as BaseMocks from "./BaseMocks";
+export * as CustomMocks from "./CustomMocks";

--- a/src/interfaces/CustomMessageReactionExtras.ts
+++ b/src/interfaces/CustomMessageReactionExtras.ts
@@ -1,0 +1,8 @@
+import Discord from "discord.js";
+
+interface CustomMessageReactionExtras {
+	client?: Discord.Client;
+	message?: Discord.Message;
+}
+
+export default CustomMessageReactionExtras;

--- a/src/interfaces/MessageConfigOptions.ts
+++ b/src/interfaces/MessageConfigOptions.ts
@@ -5,6 +5,7 @@ interface MessageConfigOptions {
 	content?: string;
 	author?: Discord.User;
 	member?: Discord.GuildMember;
+	guild?: Discord.Guild;
 	pinned?: false;
 	tts?: false;
 }

--- a/src/interfaces/MessageReactionOptions.ts
+++ b/src/interfaces/MessageReactionOptions.ts
@@ -1,0 +1,10 @@
+import Discord from "discord.js";
+
+interface MessageReactionOptions {
+	message?: Discord.Message;
+	emoji?: {
+		name?: string;
+	}
+}
+
+export default MessageReactionOptions;

--- a/test/BaseMocksTest.ts
+++ b/test/BaseMocksTest.ts
@@ -10,6 +10,7 @@ import getMessageDefaults from "../src/defaults/message";
 
 // @ts-ignore - TypeScript doesn't like that this file does not come from src/
 import { ExpicitContentFilterLevel, VerificationLevel, ChannelType } from "./enums";
+import getMessageReactionDefaults from "../src/defaults/messagerReaction";
 
 describe("BaseMocks", () => {
 	describe("::getClient()", () => {
@@ -169,6 +170,23 @@ describe("BaseMocks", () => {
 			expect(message.member?.id).to.equal(defaults.member?.id);
 			expect(message.pinned).to.equal(defaults.pinned);
 			expect(message.tts).to.equal(defaults.tts);
+		});
+	});
+
+	describe("::getMessageReaction()", () => {
+		it("returns the same Discord Message Reaction each time", () => {
+			const expected = BaseMocks.getMessageReaction();
+			const actual = BaseMocks.getMessageReaction();
+
+			expect(actual).to.equal(expected);
+		});
+
+		it("creates a new Message Reaction with the MESSAGE_REACTION_DEFAULTS", () => {
+			const reaction = BaseMocks.getMessageReaction();
+			const defaults = getMessageReactionDefaults();
+
+			expect(reaction.message).to.equal(defaults.message);
+			expect(reaction.emoji.name).to.equal(defaults.emoji.name);
 		});
 	});
 });

--- a/test/CustomMocksTest.ts
+++ b/test/CustomMocksTest.ts
@@ -8,6 +8,7 @@ import TEXT_CHANNEL_DEFAULTS from "../src/defaults/textchannel";
 import USER_DEFAULTS from "../src/defaults/user";
 import getGuildMemberDefaults from "../src/defaults/guildmember";
 import getMessageDefaults from "../src/defaults/message";
+import getMessageReactionDefaults from "../src/defaults/messagerReaction";
 
 describe("CustomMocks", () => {
 	describe("::getGuild()", () => {
@@ -217,6 +218,7 @@ describe("CustomMocks", () => {
 			expect(actual.content).to.equal(expected.content);
 			expect(actual.author.id).to.equal(expected.author.id);
 			expect(actual.member?.id).to.equal(expected.member?.id);
+			expect(actual.guild?.id).to.equal(expected.guild?.id);
 			expect(actual.pinned).to.equal(expected.pinned);
 			expect(actual.tts).to.equal(expected.tts);
 		});
@@ -242,6 +244,41 @@ describe("CustomMocks", () => {
 
 			expect(message.content).to.equal("This is a test message");
 			expect(message.content).not.to.equal(getMessageDefaults().content);
+		});
+	});
+
+	describe("::getMessageReaction()", () => {
+		it("returns a Discord Message Reaction with the default values if no options are provided", () => {
+			const expected = BaseMocks.getMessageReaction();
+			const actual = CustomMocks.getMessageReaction();
+
+			expect(actual.message).to.equal(expected.message);
+			expect(actual.emoji.name).to.equal(expected.emoji.name);
+		});
+
+		it("returns a Discord Message Reaction with the default client if no custom client is provided", () => {
+			const expected = BaseMocks.getClient();
+			const actual = CustomMocks.getMessageReaction().message.client;
+
+			expect(actual).to.equal(expected);
+		});
+
+		it("returns a Discord Message Reaction with the default message if no custom message is provided", () => {
+			const expected = BaseMocks.getMessage();
+			const actual = CustomMocks.getMessageReaction().message;
+
+			expect(actual).to.equal(expected);
+		});
+
+		it("returns a Discord Message Reaction with the given options overriding the defaults", () => {
+			const message = CustomMocks.getMessageReaction({
+				emoji: {
+					name: "test"
+				}
+			});
+
+			expect(message.emoji.name).to.equal("test");
+			expect(message.emoji.name).not.to.equal(getMessageReactionDefaults().emoji.name);
 		});
 	});
 });


### PR DESCRIPTION
#### Overview
- Added support for `BaseMocks.getMessageReaction()` and `CustomMocks.getMessageReaction()`
- Added support for customising the `guild` via `CustomMocks.getMessage()`
- Changed how `BaseMocks` and `CustomMocks` are exported
