### PR TITLE
Upgrade to discord.js v14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lambocreeper/mock-discord.js",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lambocreeper/mock-discord.js",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "WTFPL",
       "dependencies": {
         "discord.js": "^14.7.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "WTFPL",
       "dependencies": {
-        "discord.js": "^14.7.1"
+        "discord.js": "^14.8.0"
       },
       "devDependencies": {
         "@types/chai": "^4.2.13",
@@ -481,51 +481,63 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
-      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.5.0.tgz",
+      "integrity": "sha512-7XxT78mnNBPigHn2y6KAXkicxIBFtZREGWaRZ249EC1l6gBUEP8IyVY5JTciIjJArxkF+tg675aZvsTNTKBpmA==",
       "dependencies": {
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/shapeshift": "^3.8.1",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.2",
-        "tslib": "^2.4.1"
+        "ts-mixer": "^6.0.3",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
-      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.4.0.tgz",
+      "integrity": "sha512-hiOJyk2CPFf1+FL3a4VKCuu1f448LlROVuu8nLz1+jCOAPokUcdFAV+l4pd3B3h6uJlJQSASoZzrdyNdjdtfzQ==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.2.0.tgz",
+      "integrity": "sha512-vn4oMSXuMZUm8ITqVOtvE7/fMMISj4cI5oLsR09PEQXHKeKDAMLltG/DWeeIs7Idfy6V8Fk3rn1e69h7NfzuNA==",
+      "dependencies": {
+        "discord-api-types": "^0.37.35"
+      },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
-      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.6.0.tgz",
+      "integrity": "sha512-HGvqNCZ5Z5j0tQHjmT1lFvE5ETO4hvomJ1r0cbnpC1zM23XhCpZ9wgTCiEmaxKz05cyf2CI9p39+9LL+6Yz1bA==",
       "dependencies": {
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/util": "^0.1.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/util": "^0.2.0",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.23",
-        "file-type": "^18.0.0",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0"
+        "@sapphire/snowflake": "^3.4.0",
+        "discord-api-types": "^0.37.35",
+        "file-type": "^18.2.1",
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1539,27 +1551,28 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.20",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
-      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
+      "version": "0.37.35",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
+      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
     },
     "node_modules/discord.js": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
-      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.8.0.tgz",
+      "integrity": "sha512-UOxYtc/YnV7jAJ2gISluJyYeBw4e+j8gWn+IoqG8unaHAVuvZ13DdYN0M1f9fbUgUvSarV798inIrYFtDNDjwQ==",
       "dependencies": {
-        "@discordjs/builders": "^1.4.0",
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/rest": "^1.4.0",
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/builders": "^1.5.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/rest": "^1.6.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/snowflake": "^3.4.0",
+        "@types/ws": "^8.5.4",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0",
-        "ws": "^8.11.0"
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0",
+        "ws": "^8.12.1"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -3843,9 +3856,9 @@
       ]
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4578,9 +4591,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -5313,42 +5326,51 @@
       }
     },
     "@discordjs/builders": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
-      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.5.0.tgz",
+      "integrity": "sha512-7XxT78mnNBPigHn2y6KAXkicxIBFtZREGWaRZ249EC1l6gBUEP8IyVY5JTciIjJArxkF+tg675aZvsTNTKBpmA==",
       "requires": {
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/shapeshift": "^3.8.1",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.2",
-        "tslib": "^2.4.1"
+        "ts-mixer": "^6.0.3",
+        "tslib": "^2.5.0"
       }
     },
     "@discordjs/collection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
-      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.4.0.tgz",
+      "integrity": "sha512-hiOJyk2CPFf1+FL3a4VKCuu1f448LlROVuu8nLz1+jCOAPokUcdFAV+l4pd3B3h6uJlJQSASoZzrdyNdjdtfzQ=="
+    },
+    "@discordjs/formatters": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.2.0.tgz",
+      "integrity": "sha512-vn4oMSXuMZUm8ITqVOtvE7/fMMISj4cI5oLsR09PEQXHKeKDAMLltG/DWeeIs7Idfy6V8Fk3rn1e69h7NfzuNA==",
+      "requires": {
+        "discord-api-types": "^0.37.35"
+      }
     },
     "@discordjs/rest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
-      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.6.0.tgz",
+      "integrity": "sha512-HGvqNCZ5Z5j0tQHjmT1lFvE5ETO4hvomJ1r0cbnpC1zM23XhCpZ9wgTCiEmaxKz05cyf2CI9p39+9LL+6Yz1bA==",
       "requires": {
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/util": "^0.1.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/util": "^0.2.0",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.23",
-        "file-type": "^18.0.0",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0"
+        "@sapphire/snowflake": "^3.4.0",
+        "discord-api-types": "^0.37.35",
+        "file-type": "^18.2.1",
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0"
       }
     },
     "@discordjs/util": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -6097,27 +6119,28 @@
       }
     },
     "discord-api-types": {
-      "version": "0.37.20",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
-      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
+      "version": "0.37.35",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
+      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
     },
     "discord.js": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
-      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.8.0.tgz",
+      "integrity": "sha512-UOxYtc/YnV7jAJ2gISluJyYeBw4e+j8gWn+IoqG8unaHAVuvZ13DdYN0M1f9fbUgUvSarV798inIrYFtDNDjwQ==",
       "requires": {
-        "@discordjs/builders": "^1.4.0",
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/rest": "^1.4.0",
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "0.37.20",
+        "@discordjs/builders": "^1.5.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/rest": "^1.6.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/snowflake": "^3.4.0",
+        "@types/ws": "^8.5.4",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0",
-        "ws": "^8.11.0"
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0",
+        "ws": "^8.12.1"
       },
       "dependencies": {
         "@types/ws": {
@@ -7808,9 +7831,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8337,9 +8360,9 @@
       }
     },
     "undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@lambocreeper/mock-discord.js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lambocreeper/mock-discord.js",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "WTFPL",
       "dependencies": {
-        "discord.js": "^13.0.1"
+        "discord.js": "^14.7.1"
       },
       "devDependencies": {
         "@types/chai": "^4.2.13",
         "@types/mocha": "^7.0.*",
-        "@types/node": "^14.11.8",
+        "@types/node": "^18.14.6",
         "@types/sinon": "^9.0.8",
         "@types/ws": "^7.2.7",
         "@typescript-eslint/eslint-plugin": "^4.4.1",
@@ -26,7 +26,7 @@
         "nyc": "^15.1.0",
         "sinon": "^9.2.1",
         "ts-mocha": "^7.0.0",
-        "typescript": "^4.0.3"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -481,40 +481,53 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.4.0.tgz",
-      "integrity": "sha512-EiwLltKph6TSaPJIzJYdzNc1PnA2ZNaaE0t0ODg3ghnpVHqfgd0YX9/srsleYHW2cw1sfIq+kbM+h0etf7GWLA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "dependencies": {
-        "@sindresorhus/is": "^4.0.1",
-        "discord-api-types": "^0.22.0",
-        "ow": "^0.27.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.0"
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.2.1.tgz",
-      "integrity": "sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.9.0"
       }
     },
-    "node_modules/@discordjs/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
+    "node_modules/@discordjs/rest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@sapphire/snowflake": "^3.2.2",
+        "discord-api-types": "^0.37.23",
+        "file-type": "^18.0.0",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -673,23 +686,34 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz",
-      "integrity": "sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
-      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
-      "engines": {
-        "node": ">=10"
+    "node_modules/@sapphire/shapeshift": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
       },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -727,6 +751,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "node_modules/@types/chai": {
       "version": "4.2.21",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
@@ -746,9 +775,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
-      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "node_modules/@types/sinon": {
       "version": "9.0.11",
@@ -769,6 +798,7 @@
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1088,11 +1118,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1165,6 +1190,17 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -1197,6 +1233,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1377,17 +1414,6 @@
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1491,14 +1517,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1521,30 +1539,38 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.22.0.tgz",
-      "integrity": "sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "0.37.20",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
+      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
     },
     "node_modules/discord.js": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.0.1.tgz",
-      "integrity": "sha512-pEODCFfxypBnGEYpSgjkn1jt70raCS1um7Zp0AXEfW1DcR29wISzQ/WeWdnjP5KTXGi0LTtkRiUjOsMgSoukxA==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "dependencies": {
-        "@discordjs/builders": "^0.4.0",
-        "@discordjs/collection": "^0.2.1",
-        "@discordjs/form-data": "^3.0.1",
-        "@sapphire/async-queue": "^1.1.4",
-        "@types/ws": "^7.4.7",
-        "discord-api-types": "^0.22.0",
-        "node-fetch": "^2.6.1",
-        "ws": "^7.5.1"
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/snowflake": "^3.2.2",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.37.20",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.snakecase": "^4.1.1",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       },
       "engines": {
-        "node": ">=16.6.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/discord.js/node_modules/@types/ws": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/doctrine": {
@@ -1557,20 +1583,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1916,8 +1928,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.7",
@@ -1966,6 +1977,22 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -2341,6 +2368,25 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2397,8 +2443,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -2565,14 +2610,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -2866,8 +2903,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -2887,16 +2923,16 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -3049,25 +3085,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "dependencies": {
-        "mime-db": "1.49.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3274,14 +3291,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
       }
     },
     "node_modules/node-preload": {
@@ -3563,36 +3572,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ow": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.1",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.1",
-        "vali-date": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ow/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -3720,6 +3699,18 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/picomatch": {
@@ -3850,6 +3841,34 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.2.0",
@@ -4140,6 +4159,41 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -4211,6 +4265,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -4325,10 +4395,26 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/ts-mixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "node_modules/ts-mocha": {
       "version": "7.0.0",
@@ -4396,9 +4482,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -4464,9 +4550,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4491,6 +4577,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4499,6 +4596,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -4515,14 +4617,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
-    },
-    "node_modules/vali-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4732,15 +4826,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -5219,31 +5313,42 @@
       }
     },
     "@discordjs/builders": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.4.0.tgz",
-      "integrity": "sha512-EiwLltKph6TSaPJIzJYdzNc1PnA2ZNaaE0t0ODg3ghnpVHqfgd0YX9/srsleYHW2cw1sfIq+kbM+h0etf7GWLA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "requires": {
-        "@sindresorhus/is": "^4.0.1",
-        "discord-api-types": "^0.22.0",
-        "ow": "^0.27.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.0"
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       }
     },
     "@discordjs/collection": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.2.1.tgz",
-      "integrity": "sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg=="
     },
-    "@discordjs/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
+    "@discordjs/rest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@sapphire/snowflake": "^3.2.2",
+        "discord-api-types": "^0.37.23",
+        "file-type": "^18.0.0",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
       }
+    },
+    "@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -5367,14 +5472,23 @@
       }
     },
     "@sapphire/async-queue": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.4.tgz",
-      "integrity": "sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
     },
-    "@sindresorhus/is": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
-      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g=="
+    "@sapphire/shapeshift": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      }
+    },
+    "@sapphire/snowflake": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -5411,6 +5525,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@types/chai": {
       "version": "4.2.21",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
@@ -5430,9 +5549,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
-      "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "@types/sinon": {
       "version": "9.0.11",
@@ -5453,6 +5572,7 @@
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -5653,11 +5773,6 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5714,6 +5829,14 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -5739,7 +5862,8 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -5877,14 +6001,6 @@
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -5965,11 +6081,6 @@
         "object-keys": "^1.0.12"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -5986,23 +6097,37 @@
       }
     },
     "discord-api-types": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.22.0.tgz",
-      "integrity": "sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg=="
+      "version": "0.37.20",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
+      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
     },
     "discord.js": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.0.1.tgz",
-      "integrity": "sha512-pEODCFfxypBnGEYpSgjkn1jt70raCS1um7Zp0AXEfW1DcR29wISzQ/WeWdnjP5KTXGi0LTtkRiUjOsMgSoukxA==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "requires": {
-        "@discordjs/builders": "^0.4.0",
-        "@discordjs/collection": "^0.2.1",
-        "@discordjs/form-data": "^3.0.1",
-        "@sapphire/async-queue": "^1.1.4",
-        "@types/ws": "^7.4.7",
-        "discord-api-types": "^0.22.0",
-        "node-fetch": "^2.6.1",
-        "ws": "^7.5.1"
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/snowflake": "^3.2.2",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "0.37.20",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.snakecase": "^4.1.1",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
+      },
+      "dependencies": {
+        "@types/ws": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+          "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
       }
     },
     "doctrine": {
@@ -6012,14 +6137,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "dot-prop": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-      "requires": {
-        "is-obj": "^2.0.0"
       }
     },
     "electron-to-chromium": {
@@ -6283,8 +6400,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -6327,6 +6443,16 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "file-type": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
       }
     },
     "fill-range": {
@@ -6591,6 +6717,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -6632,8 +6763,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -6733,11 +6863,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -6959,8 +7084,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6980,16 +7104,16 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -7110,19 +7234,6 @@
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
-      }
-    },
-    "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
-    },
-    "mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "requires": {
-        "mime-db": "1.49.0"
       }
     },
     "minimatch": {
@@ -7292,11 +7403,6 @@
           "dev": true
         }
       }
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-preload": {
       "version": "0.2.1",
@@ -7519,26 +7625,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "ow": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-      "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-      "requires": {
-        "@sindresorhus/is": "^4.0.1",
-        "callsites": "^3.1.0",
-        "dot-prop": "^6.0.1",
-        "lodash.isequal": "^4.5.0",
-        "type-fest": "^1.2.1",
-        "vali-date": "^1.0.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-        }
-      }
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -7632,6 +7718,11 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
+    "peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -7715,6 +7806,24 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -7924,6 +8033,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -7975,6 +8104,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -8067,10 +8205,19 @@
         "is-number": "^7.0.0"
       }
     },
+    "token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
+    },
     "ts-mixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "ts-mocha": {
       "version": "7.0.0",
@@ -8120,9 +8267,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -8172,9 +8319,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {
@@ -8189,6 +8336,14 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8197,6 +8352,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "3.4.0",
@@ -8209,11 +8369,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
-    },
-    "vali-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
     },
     "which": {
       "version": "2.0.2",
@@ -8385,9 +8540,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "discord.js": "^14.7.1"
-  },
-  "overrides": {
-    "discord-api-types": "0.37.20"
+    "discord.js": "^14.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lambocreeper/mock-discord.js",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Easily mock Discord.js for testing your bot's code.",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.13",
     "@types/mocha": "^7.0.*",
-    "@types/node": "^14.11.8",
+    "@types/node": "^18.14.6",
     "@types/sinon": "^9.0.8",
     "@types/ws": "^7.2.7",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
@@ -48,9 +48,12 @@
     "nyc": "^15.1.0",
     "sinon": "^9.2.1",
     "ts-mocha": "^7.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
-    "discord.js": "^13.0.1"
+    "discord.js": "^14.7.1"
+  },
+  "overrides": {
+    "discord-api-types": "0.37.20"
   }
 }

--- a/src/BaseMocks.ts
+++ b/src/BaseMocks.ts
@@ -1,6 +1,5 @@
 import Discord from "discord.js";
 import GUILD_DEFAULTS from "./defaults/guild";
-import CHANNEL_DEFAULTS from "./defaults/channel";
 import GUILD_CHANNEL_DEFAULTS from "./defaults/guildchannel";
 import TEXT_CHANNEL_DEFAULTS from "./defaults/textchannel";
 import USER_DEFAULTS from "./defaults/user";
@@ -11,7 +10,6 @@ import MESSAGE_REACTION_DEFAULTS from "./defaults/messagerReaction";
 class BaseMocks {
 	private static client: Discord.Client;
 	private static guild: Discord.Guild;
-	private static channel: Discord.Channel;
 	private static guildChannel: Discord.GuildChannel;
 	private static textChannel: Discord.TextChannel;
 	private static user: Discord.User;
@@ -41,23 +39,10 @@ class BaseMocks {
 	 */
 	static getGuild(): Discord.Guild {
 		if (!this.guild) {
-			this.guild = new Discord.Guild(this.getClient(), GUILD_DEFAULTS);
+			this.guild = Reflect.construct(Discord.Guild, [this.getClient(), GUILD_DEFAULTS]);
 		}
 
 		return this.guild;
-	}
-
-	/**
-	 * Returns a generic and consistent mock of a Discord Channel.
-	 *
-	 * @returns {Discord.Channel}
-	 */
-	static getChannel(): Discord.Channel {
-		if (!this.channel) {
-			this.channel = new Discord.Channel(this.getClient(), CHANNEL_DEFAULTS);
-		}
-
-		return this.channel;
 	}
 
 	/**
@@ -67,7 +52,7 @@ class BaseMocks {
 	 */
 	static getGuildChannel(): Discord.GuildChannel {
 		if (!this.guildChannel) {
-			this.guildChannel = new Discord.GuildChannel(this.getGuild(), GUILD_CHANNEL_DEFAULTS);
+			this.guildChannel = Reflect.construct(Discord.GuildChannel, [this.getGuild(), GUILD_CHANNEL_DEFAULTS]);
 		}
 
 		return this.guildChannel;
@@ -80,7 +65,7 @@ class BaseMocks {
 	 */
 	static getTextChannel(): Discord.TextChannel {
 		if (!this.textChannel) {
-			this.textChannel = new Discord.TextChannel(this.getGuild(), TEXT_CHANNEL_DEFAULTS);
+			this.textChannel = Reflect.construct(Discord.TextChannel, [this.getGuild(), TEXT_CHANNEL_DEFAULTS]);
 		}
 
 		return this.textChannel;
@@ -93,7 +78,7 @@ class BaseMocks {
 	 */
 	static getUser(): Discord.User {
 		if (!this.user) {
-			this.user = new Discord.User(this.getClient(), USER_DEFAULTS);
+			this.user = Reflect.construct(Discord.User, [this.getClient(), USER_DEFAULTS]);
 		}
 
 		return this.user;
@@ -106,7 +91,7 @@ class BaseMocks {
 	 */
 	static getGuildMember(): Discord.GuildMember {
 		if (!this.guildMember) {
-			this.guildMember = new Discord.GuildMember(this.getClient(), GUILD_MEMBER_DEFAULTS, this.getGuild());
+			this.guildMember = Reflect.construct(Discord.GuildMember, [this.getClient(), GUILD_MEMBER_DEFAULTS, this.getGuild()]);
 		}
 
 		return this.guildMember;
@@ -119,7 +104,7 @@ class BaseMocks {
 	 */
 	static getMessage(): Discord.Message {
 		if (!this.message) {
-			this.message = new Discord.Message(this.getClient(), GUILD_MESSAGE_DEFAULTS);
+			this.message = Reflect.construct(Discord.Message, [this.getClient(), GUILD_MESSAGE_DEFAULTS]);
 
 			/**
 			 * Both channel and member are "getter" methods that resolve to objects
@@ -145,9 +130,7 @@ class BaseMocks {
 	 */
 	static getMessageReaction(): Discord.MessageReaction {
 		if (!this.messageReaction) {
-			this.messageReaction = new Discord.MessageReaction(
-				this.getClient(), MESSAGE_REACTION_DEFAULTS, this.getMessage()
-			);
+			this.messageReaction = Reflect.construct(Discord.MessageReaction, [this.getClient(), MESSAGE_REACTION_DEFAULTS, this.getMessage()]);
 		}
 
 		return this.messageReaction;

--- a/src/CustomMocks.ts
+++ b/src/CustomMocks.ts
@@ -5,7 +5,6 @@ import CustomGuildMemberExtras from "./interfaces/CustomGuildMemberExtras";
 import CustomMessageExtras from "./interfaces/CustomMessageExtras";
 import CustomMessageReactionExtras from "./interfaces/CustomMessageReactionExtras";
 import GUILD_DEFAULTS from "./defaults/guild";
-import CHANNEL_DEFAULTS from "./defaults/channel";
 import GUILD_CHANNEL_DEFAULTS from "./defaults/guildchannel";
 import TEXT_CHANNEL_DEFAULTS from "./defaults/textchannel";
 import USER_DEFAULTS from "./defaults/user";
@@ -20,22 +19,10 @@ class CustomMocks {
 	 * @returns {Discord.Guild}
 	 */
 	static getGuild(options?: Partial<APIGuild>, client?: Discord.Client): Discord.Guild {
-		return new Discord.Guild(client ?? BaseMocks.getClient(), {
-			...GUILD_DEFAULTS,
-			...options
-		});
-	}
+		const discordClient = client ?? BaseMocks.getClient();
+		const data = { ...GUILD_DEFAULTS, ...options };
 
-	/**
-	 * Returns a channel mock based off of given options.
-	 *
-	 * @returns {Discord.Channel}
-	 */
-	static getChannel(options?: Partial<APIChannel>, client?: Discord.Client): Discord.Channel {
-		return new Discord.Channel(client ?? BaseMocks.getClient(), {
-			...CHANNEL_DEFAULTS,
-			...options
-		});
+		return Reflect.construct(Discord.Guild, [discordClient, data]);
 	}
 
 	/**
@@ -44,10 +31,10 @@ class CustomMocks {
 	 * @returns {Discord.GuildChannel}
 	 */
 	static getGuildChannel(options?: Partial<APIChannel>, guild?: Discord.Guild): Discord.GuildChannel {
-		return new Discord.GuildChannel(guild ?? BaseMocks.getGuild(), {
-			...GUILD_CHANNEL_DEFAULTS,
-			...options
-		});
+		const discordGuild = guild ?? BaseMocks.getGuild();
+		const data = { ...GUILD_CHANNEL_DEFAULTS, ...options };
+
+		return Reflect.construct(Discord.GuildChannel, [discordGuild, data]);
 	}
 
 	/**
@@ -56,10 +43,10 @@ class CustomMocks {
 	 * @returns {Discord.TextChannel}
 	 */
 	static getTextChannel(options?: Partial<APIChannel>, guild?: Discord.Guild): Discord.TextChannel {
-		return new Discord.TextChannel(guild ?? BaseMocks.getGuild(), {
-			...TEXT_CHANNEL_DEFAULTS,
-			...options
-		});
+		const discordGuild = guild ?? BaseMocks.getGuild();
+		const data = { ...TEXT_CHANNEL_DEFAULTS, ...options };
+
+		return Reflect.construct(Discord.TextChannel, [discordGuild, data]);
 	}
 
 	/**
@@ -68,10 +55,10 @@ class CustomMocks {
 	 * @returns {Discord.User}
 	 */
 	static getUser(options?: Partial<APIUser>, client?: Discord.Client): Discord.User {
-		return new Discord.User(client ?? BaseMocks.getClient(), {
-			...USER_DEFAULTS,
-			...options
-		});
+		const discordClient = client ?? BaseMocks.getClient();
+		const data = { ...USER_DEFAULTS, ...options };
+
+		return Reflect.construct(Discord.User, [discordClient, data]);
 	}
 
 	/**
@@ -80,10 +67,11 @@ class CustomMocks {
 	 * @returns {Discord.GuildMember}
 	 */
 	static getGuildMember(options?: Partial<APIGuildMember>, extras?: CustomGuildMemberExtras): Discord.GuildMember {
-		return new Discord.GuildMember(extras?.client ?? BaseMocks.getClient(), {
-			...GUILD_MEMBER_DEFAULTS,
-			...options
-		}, extras?.guild ?? BaseMocks.getGuild());
+		const discordClient = extras?.client ?? BaseMocks.getClient();
+		const data = { ...GUILD_MEMBER_DEFAULTS, ...options };
+		const discordGuild = extras?.guild ?? BaseMocks.getGuild();
+
+		return Reflect.construct(Discord.GuildMember, [discordClient, data, discordGuild]);
 	}
 
 	/**
@@ -92,10 +80,10 @@ class CustomMocks {
 	 * @returns {Discord.Message}
 	 */
 	static getMessage(options?: Partial<APIMessage>, extras?: CustomMessageExtras): Discord.Message {
-		const message = new Discord.Message(extras?.client ?? BaseMocks.getClient(), {
-			...GUILD_MESSAGE_DEFAULTS,
-			...options
-		});
+		const discordClient = extras?.client ?? BaseMocks.getClient();
+		const data = { ...GUILD_MESSAGE_DEFAULTS, ...options };
+
+		const message = Reflect.construct(Discord.Message, [discordClient, data]);
 
 		/**
 		 * Both channel and member are "getter" methods that resolve to objects
@@ -119,10 +107,11 @@ class CustomMocks {
 	 * @returns {Discord.MessageReaction}
 	 */
 	static getMessageReaction(options?: Partial<APIReaction>, extras?: CustomMessageReactionExtras): Discord.MessageReaction {
-		return new Discord.MessageReaction(extras?.client ?? BaseMocks.getClient(), {
-			...MESSAGE_REACTION_DEFAULTS,
-			...options
-		}, extras?.message ?? BaseMocks.getMessage());
+		const discordClient = extras?.client ?? BaseMocks.getClient();
+		const data = { ...MESSAGE_REACTION_DEFAULTS, ...options };
+		const message = extras?.message ?? BaseMocks.getMessage();
+
+		return Reflect.construct(Discord.MessageReaction, [discordClient, data, message]);
 	}
 }
 

--- a/src/CustomMocks.ts
+++ b/src/CustomMocks.ts
@@ -1,6 +1,6 @@
 import Discord from "discord.js";
 import BaseMocks from "./BaseMocks";
-import { APIChannel, APIGuild, APIGuildMember, APIMessage, APIReaction, APIUser } from "discord-api-types/v9";
+import { APIChannel, APIGuild, APIGuildMember, APIMessage, APIReaction, APIUser } from "discord-api-types/v10";
 import CustomGuildMemberExtras from "./interfaces/CustomGuildMemberExtras";
 import CustomMessageExtras from "./interfaces/CustomMessageExtras";
 import CustomMessageReactionExtras from "./interfaces/CustomMessageReactionExtras";

--- a/src/defaults/channel.ts
+++ b/src/defaults/channel.ts
@@ -3,7 +3,8 @@ import { APIChannel, ChannelType } from "discord-api-types/v10";
 const CHANNEL_DEFAULTS: APIChannel = {
 	id: "121212121212121212",
 	type: ChannelType.GuildText,
-	position: 1
+	position: 1,
+	name: "my-channel"
 };
 
 export default CHANNEL_DEFAULTS;

--- a/src/defaults/channel.ts
+++ b/src/defaults/channel.ts
@@ -1,8 +1,9 @@
-import { APIChannel } from "discord-api-types/v9";
+import { APIChannel, ChannelType } from "discord-api-types/v10";
 
 const CHANNEL_DEFAULTS: APIChannel = {
 	id: "121212121212121212",
-	type: 0
+	type: ChannelType.GuildText,
+	position: 1
 };
 
 export default CHANNEL_DEFAULTS;

--- a/src/defaults/guild.ts
+++ b/src/defaults/guild.ts
@@ -1,28 +1,35 @@
-import { APIGuild, GuildNSFWLevel, GuildPremiumTier } from "discord-api-types/v9";
+import {
+	APIGuild,
+	GuildNSFWLevel,
+	GuildPremiumTier,
+	GuildVerificationLevel,
+	GuildExplicitContentFilter,
+	GuildMFALevel,
+	GuildDefaultMessageNotifications,
+	GuildSystemChannelFlags
+} from "discord-api-types/v10";
 
 const GUILD_DEFAULTS: APIGuild = {
 	id: "123456789012345678",
-	unavailable: false,
 	name: "My Guild",
 	icon: "https://placehold.it/256x256",
 	splash: "https://placehold.it/1920x1080",
 	region: "eu-west",
-	member_count: 15,
-	large: false,
+	approximate_member_count: 15,
 	features: [],
 	application_id: "876543210987654321",
-	afk_timeout: 1000,
+	afk_timeout: 900,
 	afk_channel_id: "123412341234123412",
 	system_channel_id: "876587658765876587",
-	verification_level: 1,
-	explicit_content_filter: 0,
-	mfa_level: 0,
+	verification_level: GuildVerificationLevel.Low,
+	explicit_content_filter: GuildExplicitContentFilter.Disabled,
+	mfa_level: GuildMFALevel.None,
 	owner_id: "182736451827364511",
 	discovery_splash: null,
-	default_message_notifications: 0,
+	default_message_notifications: GuildDefaultMessageNotifications.AllMessages,
 	roles: [],
 	emojis: [],
-	system_channel_flags: 1,
+	system_channel_flags: GuildSystemChannelFlags.SuppressJoinNotifications,
 	rules_channel_id: "",
 	vanity_url_code: "",
 	description: "",
@@ -31,7 +38,9 @@ const GUILD_DEFAULTS: APIGuild = {
 	preferred_locale: "",
 	public_updates_channel_id: "",
 	nsfw_level: GuildNSFWLevel.Default,
-	stickers: []
+	stickers: [],
+	premium_progress_bar_enabled: false,
+	hub_type: null
 };
 
 export default GUILD_DEFAULTS;

--- a/src/defaults/guildchannel.ts
+++ b/src/defaults/guildchannel.ts
@@ -2,8 +2,7 @@ import { APIChannel } from "discord-api-types/v10";
 import CHANNEL_DEFAULTS from "./channel";
 
 const GUILD_CHANNEL_DEFAULTS: APIChannel = {
-	...CHANNEL_DEFAULTS,
-	name: "my-channel"
+	...CHANNEL_DEFAULTS
 };
 
 export default GUILD_CHANNEL_DEFAULTS;

--- a/src/defaults/guildchannel.ts
+++ b/src/defaults/guildchannel.ts
@@ -1,10 +1,9 @@
-import { APIChannel } from "discord-api-types/v9";
+import { APIChannel } from "discord-api-types/v10";
 import CHANNEL_DEFAULTS from "./channel";
 
 const GUILD_CHANNEL_DEFAULTS: APIChannel = {
 	...CHANNEL_DEFAULTS,
-	name: "my-channel",
-	parent_id: "123123123123123123"
+	name: "my-channel"
 };
 
 export default GUILD_CHANNEL_DEFAULTS;

--- a/src/defaults/guildmember.ts
+++ b/src/defaults/guildmember.ts
@@ -1,4 +1,4 @@
-import { APIGuildMember } from "discord-api-types/v9";
+import { APIGuildMember } from "discord-api-types/v10";
 import USER_DEFAULTS from "./user";
 
 const GUILD_MEMBER_DEFAULTS: APIGuildMember = {

--- a/src/defaults/guildmember.ts
+++ b/src/defaults/guildmember.ts
@@ -7,7 +7,8 @@ const GUILD_MEMBER_DEFAULTS: APIGuildMember = {
 	roles: [],
 	joined_at: new Date().toISOString(),
 	deaf: false,
-	mute: false
+	mute: false,
+	flags: 0 // Defaults to 0
 };
 
 export default GUILD_MEMBER_DEFAULTS;

--- a/src/defaults/message.ts
+++ b/src/defaults/message.ts
@@ -1,13 +1,11 @@
-import { APIMessage } from "discord-api-types/v9";
+import { APIMessage, MessageType } from "discord-api-types/v10";
 import USER_DEFAULTS from "./user";
-import GUILD_MEMBER_DEFAULTS from "./guildmember";
 
 const GUILD_MESSAGE_DEFAULTS: APIMessage = {
 	id: "123456123456123456",
 	channel_id: "121212121212121212",
 	content: "This is a message.",
 	author: USER_DEFAULTS,
-	member: GUILD_MEMBER_DEFAULTS,
 	pinned: false,
 	tts: false,
 	timestamp: "",
@@ -17,7 +15,7 @@ const GUILD_MESSAGE_DEFAULTS: APIMessage = {
 	mentions: [],
 	attachments: [],
 	embeds: [],
-	type: 0
+	type: MessageType.Default
 };
 
 export default GUILD_MESSAGE_DEFAULTS;

--- a/src/defaults/messagerReaction.ts
+++ b/src/defaults/messagerReaction.ts
@@ -1,4 +1,4 @@
-import { APIReaction } from "discord-api-types/v9";
+import { APIReaction } from "discord-api-types/v10";
 
 const MESSAGE_REACTION_DEFAULTS: APIReaction = {
 	me: false,

--- a/src/defaults/textchannel.ts
+++ b/src/defaults/textchannel.ts
@@ -1,8 +1,12 @@
-import { APIChannel } from "discord-api-types/v9";
+import { APITextChannel, ChannelType } from "discord-api-types/v10";
 import GUILD_CHANNEL_DEFAULTS from "./guildchannel";
 
-const TEXT_CHANNEL_DEFAULTS: APIChannel = {
+const TEXT_CHANNEL_DEFAULTS: APITextChannel = {
 	...GUILD_CHANNEL_DEFAULTS,
+	type: ChannelType.GuildText,
+	name: "my-channel",
+	position: 1,
+	parent_id: "123123123123123123",
 	topic: "some-topic",
 	nsfw: false,
 	last_message_id: "123212321232123212",

--- a/src/defaults/user.ts
+++ b/src/defaults/user.ts
@@ -1,4 +1,4 @@
-import { APIUser } from "discord-api-types/v9";
+import { APIUser } from "discord-api-types/v10";
 
 const USER_DEFAULTS: APIUser = {
 	id: "010101010101010101",

--- a/test/BaseMocksTest.ts
+++ b/test/BaseMocksTest.ts
@@ -8,6 +8,15 @@ import USER_DEFAULTS from "../src/defaults/user";
 import GUILD_MEMBER_DEFAULTS from "../src/defaults/guildmember";
 import GUILD_MESSAGE_DEFAULTS from "../src/defaults/message";
 import MESSAGE_REACTION_DEFAULTS from "../src/defaults/messagerReaction";
+import {
+	GuildNSFWLevel,
+	GuildPremiumTier,
+	GuildVerificationLevel,
+	GuildExplicitContentFilter,
+	GuildMFALevel,
+	GuildDefaultMessageNotifications,
+	GuildSystemChannelFlags
+} from "discord-api-types/v10";
 
 // @ts-ignore - TypeScript doesn't like that this file does not come from src/
 import { ExpicitContentFilterLevel, VerificationLevel, ChannelType } from "./enums";
@@ -34,36 +43,22 @@ describe("BaseMocks", () => {
 			const guild = BaseMocks.getGuild();
 
 			expect(guild.id).to.equal(GUILD_DEFAULTS.id);
-			expect(guild.available).to.equal(GUILD_DEFAULTS.unavailable);
 			expect(guild.name).to.equal(GUILD_DEFAULTS.name);
 			expect(guild.icon).to.equal(GUILD_DEFAULTS.icon);
 			expect(guild.splash).to.equal(GUILD_DEFAULTS.splash);
-			expect(guild.memberCount).to.equal(GUILD_DEFAULTS.member_count);
-			expect(guild.large).to.equal(GUILD_DEFAULTS.large);
+			expect(guild.approximateMemberCount).to.equal(GUILD_DEFAULTS.approximate_member_count);
 			expect(guild.features).to.equal(GUILD_DEFAULTS.features);
 			expect(guild.applicationId).to.equal(GUILD_DEFAULTS.application_id);
 			expect(guild.afkTimeout).to.equal(GUILD_DEFAULTS.afk_timeout);
 			expect(guild.afkChannelId).to.equal(GUILD_DEFAULTS.afk_channel_id);
 			expect(guild.systemChannelId).to.equal(GUILD_DEFAULTS.system_channel_id);
-			expect(guild.verificationLevel).to.equal(VerificationLevel[GUILD_DEFAULTS.verification_level!]);
-			expect(guild.explicitContentFilter).to.equal(ExpicitContentFilterLevel[GUILD_DEFAULTS.explicit_content_filter!]);
-			expect(guild.mfaLevel).to.equal("NONE");
+			expect(guild.verificationLevel).to.equal(GuildVerificationLevel.Low);
+			expect(guild.explicitContentFilter).to.equal(GuildExplicitContentFilter.Disabled);
+			expect(guild.mfaLevel).to.equal(GuildMFALevel.None);
+			expect(guild.systemChannelFlags.bitfield).to.equal(GuildSystemChannelFlags.SuppressJoinNotifications);
+			expect(guild.premiumTier).to.equal(GuildPremiumTier.None);
+			expect(guild.nsfwLevel).to.equal(GuildNSFWLevel.Default);
 			expect(guild.ownerId).to.equal(GUILD_DEFAULTS.owner_id);
-		});
-	});
-
-	describe("::getChannel()", () => {
-		it("returns the same Discord Channel each time", () => {
-			const expected = BaseMocks.getChannel();
-			const actual = BaseMocks.getChannel();
-
-			expect(actual).to.equal(expected);
-		});
-
-		it("creates a new Discord Channel with the CHANNEL_DEFAULTS", () => {
-			const channel = BaseMocks.getChannel();
-
-			expect(channel.id).to.equal(CHANNEL_DEFAULTS.id);
 		});
 	});
 
@@ -80,7 +75,6 @@ describe("BaseMocks", () => {
 
 			expect(channel.id).to.equal(GUILD_CHANNEL_DEFAULTS.id);
 			expect(channel.name).to.equal(GUILD_CHANNEL_DEFAULTS.name);
-			expect(channel.parentId).to.equal(GUILD_CHANNEL_DEFAULTS.parent_id);
 		});
 	});
 
@@ -156,7 +150,6 @@ describe("BaseMocks", () => {
 			expect(message.id).to.equal(defaults.id);
 			expect(message.content).to.equal(defaults.content);
 			expect(message.author.id).to.equal(defaults.author?.id);
-			expect(message.member?.id).to.equal(defaults.member?.id);
 			expect(message.pinned).to.equal(defaults.pinned);
 			expect(message.tts).to.equal(defaults.tts);
 		});

--- a/test/CustomMocksTest.ts
+++ b/test/CustomMocksTest.ts
@@ -10,7 +10,7 @@ import GUILD_MEMBER_DEFAULTS from "../src/defaults/guildmember";
 import GUILD_MESSAGE_DEFAULTS from "../src/defaults/message";
 import MESSAGE_REACTION_DEFAULTS from "../src/defaults/messagerReaction";
 
-describe.only("CustomMocks", () => {
+describe("CustomMocks", () => {
 	describe("::getGuild()", () => {
 		it("returns a Discord Guild with the default values if no options are provided", () => {
 			const expected = BaseMocks.getGuild();
@@ -51,34 +51,6 @@ describe.only("CustomMocks", () => {
 		});
 	});
 
-	describe("::getChannel()", () => {
-		it("returns a Discord Channel with the default values if no options are provided", () => {
-			const expected = BaseMocks.getChannel();
-			const actual = CustomMocks.getChannel();
-
-			expect(actual.client).to.equal(expected.client);
-			expect(actual.id).to.equal(expected.id);
-			expect(actual.type).to.equal(expected.type);
-			expect(actual.deleted).to.equal(expected.deleted);
-		});
-
-		it("returns a Discord Channel with the default client if no custom client is provided", () => {
-			const expected = BaseMocks.getClient();
-			const actual = CustomMocks.getChannel().client;
-
-			expect(actual).to.equal(expected);
-		});
-
-		it("returns a Discord Channel with your given options overriding the defaults", () => {
-			const channel = CustomMocks.getChannel({
-				id: "123"
-			});
-
-			expect(channel.id).to.equal("123");
-			expect(channel.id).not.to.equal(CHANNEL_DEFAULTS.id);
-		});
-	});
-
 	describe("::getGuildChannel()", () => {
 		it("returns a Discord Guild Channel with the default values if no options are provided", () => {
 			const expected = BaseMocks.getGuildChannel();
@@ -87,9 +59,8 @@ describe.only("CustomMocks", () => {
 			expect(actual.client).to.equal(expected.client);
 			expect(actual.id).to.equal(expected.id);
 			expect(actual.type).to.equal(expected.type);
-			expect(actual.deleted).to.equal(expected.deleted);
 			expect(actual.name).to.equal(expected.name);
-			expect(actual.parentID).to.equal(expected.parentID);
+			expect(actual.parentId).to.equal(expected.parentId);
 		});
 
 		it("returns a Discord Guild Channel with the default guild if no custom guild is provided", () => {
@@ -117,12 +88,11 @@ describe.only("CustomMocks", () => {
 			expect(actual.guild).to.equal(expected.guild);
 			expect(actual.id).to.equal(expected.id);
 			expect(actual.type).to.equal(expected.type);
-			expect(actual.deleted).to.equal(expected.deleted);
 			expect(actual.name).to.equal(expected.name);
-			expect(actual.parentID).to.equal(expected.parentID);
+			expect(actual.parentId).to.equal(expected.parentId);
 			expect(actual.topic).to.equal(expected.topic);
 			expect(actual.nsfw).to.equal(expected.nsfw);
-			expect(actual.lastMessageID).to.equal(expected.lastMessageID);
+			expect(actual.lastMessageId).to.equal(expected.lastMessageId);
 			expect(actual.lastPinTimestamp).to.equal(expected.lastPinTimestamp);
 			expect(actual.rateLimitPerUser).to.equal(expected.rateLimitPerUser);
 		});
@@ -269,7 +239,7 @@ describe.only("CustomMocks", () => {
 		it("returns a Discord Message Reaction with the given options overriding the defaults", () => {
 			const message = CustomMocks.getMessageReaction({
 				emoji: {
-				    id: null,
+					id: null,
 					name: "test"
 				}
 			});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "module": "commonjs",
     "outDir": "./build",
     "rootDir": "./src",


### PR DESCRIPTION
Resolves #14 

Breaking changes with upgrading discord.js v13 to v14

## Changes
- Classes with private/protected constructors have been changed to use `Reflect.construct()` method to be able to create instances of the classes
- Updated certain magic number values to use the new enum types eg. `GuildVerificationLevel`, `ChannelType`, etc.
- Removed `getChannel()` in `BaseMocks`, constructor is not available anymore so no base generic channel to be used
- Updated default properties
- Removed the `.only` set in `CustomMocksTest`